### PR TITLE
Fix color of headings in mobile version

### DIFF
--- a/assets/static/css/home.css
+++ b/assets/static/css/home.css
@@ -15,7 +15,7 @@ a.ugly-button {
 
 .section-headline {
   font-size: 1.5em;
-  color: #0b1729;
+  color: #46b6ee;
   border-bottom: 1px solid #46b6ee;
   margin: 2em 0 1em 0;
   padding: 0 0 0.3em 0;


### PR DESCRIPTION
Before:
![mobile_headings](https://user-images.githubusercontent.com/218061/104652629-af9a5e00-56b9-11eb-95bf-6bae3c09a574.png)

After:
![mobile_headings_fixed](https://user-images.githubusercontent.com/218061/104652626-ae693100-56b9-11eb-87ce-c5c050b44c57.png)

Fixes #20